### PR TITLE
Remove needs cxx11

### DIFF
--- a/Formula/nixio-static.rb
+++ b/Formula/nixio-static.rb
@@ -10,8 +10,6 @@ class NixioStatic < Formula
   depends_on "cppunit"
   depends_on "boost"
 
-  needs :cxx11
-
   resource "demofile" do
     url "https://raw.githubusercontent.com/G-Node/nix-demo/master/data/spike_features.h5"
     sha256 "b486202df0527545cd53968545d5fb3700567dbf10fbf7d9ca9d9a98fe2998ac"

--- a/Formula/nixio.rb
+++ b/Formula/nixio.rb
@@ -10,8 +10,6 @@ class Nixio < Formula
   depends_on "cppunit"
   depends_on "boost"
 
-  needs :cxx11
-  
   resource "demofile" do
     url "https://raw.githubusercontent.com/G-Node/nix-demo/master/data/spike_features.h5"
     sha256 "b486202df0527545cd53968545d5fb3700567dbf10fbf7d9ca9d9a98fe2998ac"


### PR DESCRIPTION
It looks like "needs cxx11" isn't a supported option anymore and hasn't
been needed for some time now. Currently the option breaks the formula
and makes it impossible to install.